### PR TITLE
[Feature] Retrieve all anime & manga entries

### DIFF
--- a/core/network/src/commonMain/kotlin/com/chesire/nekomp/core/network/ResultConverterFactory.kt
+++ b/core/network/src/commonMain/kotlin/com/chesire/nekomp/core/network/ResultConverterFactory.kt
@@ -36,7 +36,7 @@ class ResultConverterFactory : Converter.Factory {
                                     Result.success(convertedBody)
                                 } catch (ex: Throwable) {
                                     Logger.e("ResultConverterFactory", ex) {
-                                        "Issue when building result from success call"
+                                        "Issue when building result from success call - $ex"
                                     }
                                     Result.failure(ex)
                                 }
@@ -59,7 +59,7 @@ class ResultConverterFactory : Converter.Factory {
 
                         is KtorfitResult.Failure -> {
                             Logger.e("ResultConverterFactory", result.throwable) {
-                                "Got Ktorfit result failure"
+                                "Got Ktorfit result failure - ${result.throwable}"
                             }
                             Result.failure(NetworkError.Generic(result.throwable))
                         }

--- a/feature/library/src/commonMain/kotlin/com/chesire/nekomp/feature/library/ui/LibraryScreen.kt
+++ b/feature/library/src/commonMain/kotlin/com/chesire/nekomp/feature/library/ui/LibraryScreen.kt
@@ -137,7 +137,7 @@ private fun ListContent(
     ) {
         items(
             items = entries,
-            key = { it.title }
+            key = { it.id }
         ) {
             ListItem(it, onEntryClick)
         }

--- a/feature/library/src/commonMain/kotlin/com/chesire/nekomp/feature/library/ui/LibraryViewModel.kt
+++ b/feature/library/src/commonMain/kotlin/com/chesire/nekomp/feature/library/ui/LibraryViewModel.kt
@@ -30,6 +30,7 @@ class LibraryViewModel(
                         entries = entries
                             .map {
                                 Entry(
+                                    id = it.id,
                                     title = it.title,
                                     image = it.posterImage
                                 )

--- a/feature/library/src/commonMain/kotlin/com/chesire/nekomp/feature/library/ui/UIState.kt
+++ b/feature/library/src/commonMain/kotlin/com/chesire/nekomp/feature/library/ui/UIState.kt
@@ -9,6 +9,7 @@ data class UIState(
 )
 
 data class Entry(
+    val id: Int,
     val title: String,
     val image: String
 )

--- a/feature/login/src/commonMain/kotlin/com/chesire/nekomp/feature/login/ui/LoginViewModel.kt
+++ b/feature/login/src/commonMain/kotlin/com/chesire/nekomp/feature/login/ui/LoginViewModel.kt
@@ -49,11 +49,11 @@ class LoginViewModel(private val performLogin: PerformLoginUseCase) : ViewModel(
                 } else {
                     when (loginResult.error) {
                         AuthFailure.BadRequest -> ViewEvent.LoginFailure(
-                            getString(NekoRes.string.login_error_invalid_credentials)
+                            getString(NekoRes.string.login_error_generic)
                         )
 
                         AuthFailure.InvalidCredentials -> ViewEvent.LoginFailure(
-                            getString(NekoRes.string.login_error_generic)
+                            getString(NekoRes.string.login_error_invalid_credentials)
                         )
                     }
                 }

--- a/library/datasource/library/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/library/LibraryRepository.kt
+++ b/library/datasource/library/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/library/LibraryRepository.kt
@@ -1,43 +1,88 @@
 package com.chesire.nekomp.library.datasource.library
 
+import co.touchlab.kermit.Logger
 import com.chesire.nekomp.library.datasource.library.local.LibraryStorage
 import com.chesire.nekomp.library.datasource.library.remote.LibraryApi
 import com.chesire.nekomp.library.datasource.library.remote.model.DataDto
 import com.chesire.nekomp.library.datasource.library.remote.model.IncludedDto
 import com.chesire.nekomp.library.datasource.library.remote.model.RetrieveResponseDto
 import com.chesire.nekomp.library.datasource.user.UserRepository
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.anyOk
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
+import kotlin.Result as KResult
 
 private const val LIMIT = 20
 
+// TODO: Add a remote data source that converts the dtos appropriately?
+// TODO: Handle errors and maybe retrying?
 class LibraryRepository(
     private val libraryApi: LibraryApi,
     private val libraryStorage: LibraryStorage,
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository // TODO: Inject method to get the user id?
 ) {
 
     val libraryEntries: Flow<List<LibraryEntry>> = libraryStorage.libraryEntries
 
-    suspend fun retrieve(): Result<List<LibraryEntry>> {
-        // TODO: Add a remote data source that converts the dtos appropriately
-        // For now retrieve 20 anime, it should cycle through getting all of them using pagination
-        // it should also pull all the manga in the call
-        val user = userRepository.user.first()
-        if (!user.isAuthenticated) {
-            return Result.failure(Throwable()) // TODO: Add custom exception for no user
+    suspend fun retrieve(): Result<Unit, Unit> {
+        Logger.d("LibraryRepository") { "Making call to retrieve library entries" }
+        val user = userRepository.user.firstOrNull()
+        if (user?.isAuthenticated != true) {
+            Logger.e("LibraryRepository") { "No user object, cancelling retrieve" }
+            return Err(Unit) // TODO: Add custom error type
         }
-        return libraryApi.retrieveAnime(user.id, 0, LIMIT)
-            .map { dto ->
-                if (dto.included == null) {
-                    emptyList()
-                } else {
-                    buildEntries(dto)
+
+        val result = coroutineScope {
+            awaitAll(
+                async { retrieve(user.id, libraryApi::retrieveAnime) },
+                async { retrieve(user.id, libraryApi::retrieveManga) }
+            )
+        }
+
+        return if (result.anyOk()) Ok(Unit) else Err(Unit)
+    }
+
+    private suspend fun retrieve(
+        userId: Int,
+        apiCall: suspend (userId: Int, offset: Int, limit: Int) -> KResult<RetrieveResponseDto>
+    ): Result<List<LibraryEntry>, Unit> {
+        var isSuccess = false
+        val entries = mutableListOf<LibraryEntry>()
+        var offset = 0
+        var page = 0
+        var next = ""
+        do {
+            apiCall(userId, offset, LIMIT)
+                .map { dto ->
+                    next = dto.links.next
+                    page++
+                    offset = LIMIT * page
+                    if (dto.included == null) {
+                        emptyList()
+                    } else {
+                        buildEntries(dto)
+                    }
                 }
-            }
-            .onSuccess {
-                libraryStorage.updateEntries(it)
-            }
+                .onSuccess {
+                    isSuccess = true
+                    entries.addAll(it)
+                    libraryStorage.updateEntries(it)
+                }
+                .onFailure {
+                    return@retrieve Err(Unit)
+                }
+        } while (next.isNotBlank())
+
+        Logger.d("LibraryRepository") {
+            "Retrieve call $apiCall, got entries [$isSuccess], total entries ${entries.count()}"
+        }
+        return if (isSuccess) Ok(entries) else Err(Unit)
     }
 
     private fun buildEntries(body: RetrieveResponseDto): List<LibraryEntry> {

--- a/library/datasource/library/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/library/remote/model/RetrieveResponseDto.kt
+++ b/library/datasource/library/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/library/remote/model/RetrieveResponseDto.kt
@@ -77,7 +77,7 @@ data class IncludedDto(
         @SerialName("canonicalTitle")
         val canonicalTitle: String,
         @SerialName("titles")
-        val titles: Map<String, String>,
+        val titles: Map<String, String?>,
         @SerialName("startDate")
         val startDate: String?,
         @SerialName("endDate")


### PR DESCRIPTION
Cycle through and pull down every anime and manga entry.
Update some error logging to be easier to read.
Fix entry not being pulled down because of nullable title.
Fix wrong error message for logging in.