### PR TITLE
[Refactor] Update grid item view

### DIFF
--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <!-- Generic -->
     <string name="app_name">Nekomp</string>
+    <string name="grid_item_plus_one">Increment series by 1</string>
 
     <!-- Navigation -->
     <string name="nav_home">Home</string>

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -36,6 +36,7 @@ kotlin {
             implementation(compose.preview)
         }
         commonMain.dependencies {
+            implementation(projects.core.resources)
             implementation(compose.animationGraphics)
             implementation(compose.components.resources)
             implementation(compose.components.uiToolingPreview)
@@ -45,6 +46,8 @@ kotlin {
             implementation(compose.materialIconsExtended)
             implementation(compose.runtime)
             implementation(compose.ui)
+            implementation(libs.coil.compose)
+            implementation(libs.coil.network.ktor)
             implementation(libs.kotlinx.collections.immutable)
         }
     }

--- a/core/ui/src/commonMain/kotlin/com/chesire/nekomp/core/ui/component/series/SeriesGridItem.kt
+++ b/core/ui/src/commonMain/kotlin/com/chesire/nekomp/core/ui/component/series/SeriesGridItem.kt
@@ -1,5 +1,6 @@
 package com.chesire.nekomp.core.ui.component.series
 
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -18,8 +19,10 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ProgressIndicatorDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -28,9 +31,11 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.chesire.nekomp.core.resources.NekoRes
+import com.chesire.nekomp.core.ui.NekompTheme
 import com.chesire.nekomp.core.ui.theme.Values
 import nekomp.core.resources.generated.resources.grid_item_plus_one
 import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun SeriesGridItem(
@@ -38,10 +43,16 @@ fun SeriesGridItem(
     backgroundImage: String,
     progress: String,
     progressPercent: Float,
+    isUpdating: Boolean,
     modifier: Modifier = Modifier,
+    showPlusButton: Boolean = true,
     onClick: () -> Unit,
     onPlusClick: () -> Unit
 ) {
+    val progressBarValue by animateFloatAsState(
+        targetValue = progressPercent,
+        animationSpec = ProgressIndicatorDefaults.ProgressAnimationSpec
+    )
     Column(
         modifier = modifier.width(IntrinsicSize.Min),
         verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -86,15 +97,20 @@ fun SeriesGridItem(
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis
                         )
-                        IconButton(onClick = onPlusClick) {
-                            Icon(
-                                imageVector = Icons.Default.PlusOne,
-                                contentDescription = stringResource(NekoRes.string.grid_item_plus_one)
-                            )
+                        if (showPlusButton) {
+                            IconButton(
+                                onClick = onPlusClick,
+                                enabled = !isUpdating
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.PlusOne,
+                                    contentDescription = stringResource(NekoRes.string.grid_item_plus_one)
+                                )
+                            }
                         }
                     }
                     LinearProgressIndicator(
-                        progress = { progressPercent },
+                        progress = { progressBarValue },
                         modifier = Modifier.height(4.dp),
                         gapSize = 0.dp,
                         drawStopIndicator = {}
@@ -108,6 +124,42 @@ fun SeriesGridItem(
             minLines = 2,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun DefaultSeriesGridItemPreview() {
+    NekompTheme {
+        SeriesGridItem(
+            title = "Title",
+            backgroundImage = "",
+            progress = "6 / 12",
+            progressPercent = 0.5f,
+            isUpdating = false,
+            modifier = Modifier,
+            showPlusButton = true,
+            onClick = {},
+            onPlusClick = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun UpdatingSeriesGridItemPreview() {
+    NekompTheme {
+        SeriesGridItem(
+            title = "Title",
+            backgroundImage = "",
+            progress = "1 / 12",
+            progressPercent = 0.1f,
+            isUpdating = true,
+            modifier = Modifier,
+            showPlusButton = true,
+            onClick = {},
+            onPlusClick = {}
         )
     }
 }

--- a/core/ui/src/commonMain/kotlin/com/chesire/nekomp/core/ui/component/series/SeriesGridItem.kt
+++ b/core/ui/src/commonMain/kotlin/com/chesire/nekomp/core/ui/component/series/SeriesGridItem.kt
@@ -8,8 +8,8 @@ import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PlusOne
 import androidx.compose.material3.Card
@@ -19,19 +19,15 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedIconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.chesire.nekomp.core.resources.NekoRes
+import com.chesire.nekomp.core.ui.theme.Values
 import nekomp.core.resources.generated.resources.grid_item_plus_one
 import org.jetbrains.compose.resources.stringResource
 
@@ -44,9 +40,6 @@ fun SeriesGridItem(
     onClick: () -> Unit,
     onPlusClick: () -> Unit
 ) {
-    var width by remember { mutableStateOf(0.dp) }
-    val density = LocalDensity.current
-
     Column(
         modifier = modifier.width(IntrinsicSize.Min),
         verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -54,22 +47,13 @@ fun SeriesGridItem(
     ) {
         Card(
             onClick = { onClick() },
-            modifier = Modifier.wrapContentSize(),
+            modifier = Modifier.size(width = Values.GridItemWidth, height = Values.GridItemHeight),
         ) {
-            Box(
-                modifier = Modifier
-                    .height(IntrinsicSize.Min)
-                    .width(IntrinsicSize.Min)
-            ) {
+            Box {
                 AsyncImage(
                     model = backgroundImage,
                     contentDescription = null,
-                    modifier = Modifier.fillMaxHeight(),
-                    onState = {
-                        width = with(density) {
-                            it.painter?.intrinsicSize?.width?.toInt()?.toDp() ?: 0.dp
-                        }
-                    }
+                    modifier = Modifier.fillMaxHeight()
                 )
                 Box(
                     modifier = Modifier
@@ -84,7 +68,7 @@ fun SeriesGridItem(
                         )
                 )
                 Column(
-                    modifier = Modifier.fillMaxHeight().width(width),
+                    modifier = Modifier.fillMaxHeight(),
                     verticalArrangement = Arrangement.Bottom,
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {

--- a/core/ui/src/commonMain/kotlin/com/chesire/nekomp/core/ui/component/series/SeriesGridItem.kt
+++ b/core/ui/src/commonMain/kotlin/com/chesire/nekomp/core/ui/component/series/SeriesGridItem.kt
@@ -5,9 +5,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
-import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
@@ -35,7 +36,8 @@ import org.jetbrains.compose.resources.stringResource
 fun SeriesGridItem(
     title: String,
     backgroundImage: String,
-    progress: Float,
+    progress: String,
+    progressPercent: Float,
     modifier: Modifier = Modifier,
     onClick: () -> Unit,
     onPlusClick: () -> Unit
@@ -46,14 +48,14 @@ fun SeriesGridItem(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Card(
-            onClick = { onClick() },
+            onClick = onClick,
             modifier = Modifier.size(width = Values.GridItemWidth, height = Values.GridItemHeight),
         ) {
             Box {
                 AsyncImage(
                     model = backgroundImage,
                     contentDescription = null,
-                    modifier = Modifier.fillMaxHeight()
+                    modifier = Modifier.fillMaxSize()
                 )
                 Box(
                     modifier = Modifier
@@ -68,18 +70,28 @@ fun SeriesGridItem(
                         )
                 )
                 Column(
-                    modifier = Modifier.fillMaxHeight(),
+                    modifier = Modifier.fillMaxSize(),
                     verticalArrangement = Arrangement.Bottom,
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    OutlinedIconButton(onClick = { onPlusClick() }) {
-                        Icon(
-                            imageVector = Icons.Default.PlusOne,
-                            contentDescription = stringResource(NekoRes.string.grid_item_plus_one)
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.padding(horizontal = 8.dp)
+                    ) {
+                        Text(
+                            text = progress,
+                            modifier = Modifier.weight(1f)
                         )
+                        OutlinedIconButton(onClick = onPlusClick) {
+                            Icon(
+                                imageVector = Icons.Default.PlusOne,
+                                contentDescription = stringResource(NekoRes.string.grid_item_plus_one)
+                            )
+                        }
                     }
                     LinearProgressIndicator(
-                        progress = { progress },
+                        progress = { progressPercent },
                         modifier = Modifier.height(4.dp),
                         gapSize = 0.dp,
                         drawStopIndicator = {}

--- a/core/ui/src/commonMain/kotlin/com/chesire/nekomp/core/ui/component/series/SeriesGridItem.kt
+++ b/core/ui/src/commonMain/kotlin/com/chesire/nekomp/core/ui/component/series/SeriesGridItem.kt
@@ -15,9 +15,9 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PlusOne
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedIconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -77,13 +77,16 @@ fun SeriesGridItem(
                     Row(
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                         verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.padding(horizontal = 8.dp)
+                        modifier = Modifier.padding(start = 8.dp)
                     ) {
                         Text(
                             text = progress,
-                            modifier = Modifier.weight(1f)
+                            modifier = Modifier.weight(1f),
+                            style = MaterialTheme.typography.titleSmall,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
                         )
-                        OutlinedIconButton(onClick = onPlusClick) {
+                        IconButton(onClick = onPlusClick) {
                             Icon(
                                 imageVector = Icons.Default.PlusOne,
                                 contentDescription = stringResource(NekoRes.string.grid_item_plus_one)

--- a/core/ui/src/commonMain/kotlin/com/chesire/nekomp/core/ui/component/series/SeriesGridItem.kt
+++ b/core/ui/src/commonMain/kotlin/com/chesire/nekomp/core/ui/component/series/SeriesGridItem.kt
@@ -1,0 +1,114 @@
+package com.chesire.nekomp.core.ui.component.series
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlusOne
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedIconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.chesire.nekomp.core.resources.NekoRes
+import nekomp.core.resources.generated.resources.grid_item_plus_one
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun SeriesGridItem(
+    title: String,
+    backgroundImage: String,
+    progress: Float,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+    onPlusClick: () -> Unit
+) {
+    var width by remember { mutableStateOf(0.dp) }
+    val density = LocalDensity.current
+
+    Column(
+        modifier = modifier.width(IntrinsicSize.Min),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Card(
+            onClick = { onClick() },
+            modifier = Modifier.wrapContentSize(),
+        ) {
+            Box(
+                modifier = Modifier
+                    .height(IntrinsicSize.Min)
+                    .width(IntrinsicSize.Min)
+            ) {
+                AsyncImage(
+                    model = backgroundImage,
+                    contentDescription = null,
+                    modifier = Modifier.fillMaxHeight(),
+                    onState = {
+                        width = with(density) {
+                            it.painter?.intrinsicSize?.width?.toInt()?.toDp() ?: 0.dp
+                        }
+                    }
+                )
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(
+                            brush = Brush.verticalGradient(
+                                .5F to Color.Transparent,
+                                .7f to MaterialTheme.colorScheme.background.copy(alpha = 0.5f),
+                                .8f to MaterialTheme.colorScheme.background.copy(alpha = 0.9f),
+                                1F to MaterialTheme.colorScheme.background.copy(alpha = 1f)
+                            )
+                        )
+                )
+                Column(
+                    modifier = Modifier.fillMaxHeight().width(width),
+                    verticalArrangement = Arrangement.Bottom,
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    OutlinedIconButton(onClick = { onPlusClick() }) {
+                        Icon(
+                            imageVector = Icons.Default.PlusOne,
+                            contentDescription = stringResource(NekoRes.string.grid_item_plus_one)
+                        )
+                    }
+                    LinearProgressIndicator(
+                        progress = { progress },
+                        modifier = Modifier.height(4.dp),
+                        gapSize = 0.dp,
+                        drawStopIndicator = {}
+                    )
+                }
+            }
+        }
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleSmall,
+            minLines = 2,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}

--- a/core/ui/src/commonMain/kotlin/com/chesire/nekomp/core/ui/theme/Values.kt
+++ b/core/ui/src/commonMain/kotlin/com/chesire/nekomp/core/ui/theme/Values.kt
@@ -1,0 +1,16 @@
+package com.chesire.nekomp.core.ui.theme
+
+import androidx.compose.ui.unit.dp
+
+object Values {
+
+    /**
+     * Value is based on previous measurement of the grid items.
+     */
+    val GridItemHeight = 211.dp
+
+    /**
+     * Value is based on previous measurement of the grid items.
+     */
+    val GridItemWidth = 148.57.dp
+}

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -44,6 +44,7 @@ kotlin {
             implementation(projects.core.network)
             implementation(projects.core.preferences)
             implementation(projects.core.resources)
+            implementation(projects.core.ui)
             implementation(projects.library.datasource.airing)
             implementation(projects.library.datasource.auth)
             implementation(projects.library.datasource.library)

--- a/feature/home/src/commonMain/kotlin/com/chesire/nekomp/feature/home/ui/HomeViewModel.kt
+++ b/feature/home/src/commonMain/kotlin/com/chesire/nekomp/feature/home/ui/HomeViewModel.kt
@@ -152,12 +152,9 @@ class HomeViewModel(
             entryId = entryId,
             title = titles.toChosenLanguage(titleLanguage),
             posterImage = posterImage.toBestImage(imageQuality),
-            progressPercent = if (totalLength == 0) {
-                0f
-            } else {
-                (progress.toFloat() / totalLength.toFloat())
-            },
-            progress = progress
+            progressPercent = progressPercent,
+            progress = progress,
+            progressDisplay = "$progress / $displayTotalLength"
         )
     }
 

--- a/feature/home/src/commonMain/kotlin/com/chesire/nekomp/feature/home/ui/HomeViewModel.kt
+++ b/feature/home/src/commonMain/kotlin/com/chesire/nekomp/feature/home/ui/HomeViewModel.kt
@@ -2,6 +2,7 @@ package com.chesire.nekomp.feature.home.ui
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.chesire.nekomp.core.coroutines.combine
 import com.chesire.nekomp.core.ext.toBestImage
 import com.chesire.nekomp.core.ext.toChosenLanguage
 import com.chesire.nekomp.core.model.EntryStatus
@@ -78,6 +79,7 @@ class HomeViewModel(
         )
     }
     private val _airingSeries = showAiringSeries().map { it.toPersistentList() }
+    private val _pendingUpdates = MutableStateFlow<List<Int>>(emptyList())
     private val _viewEvent = MutableStateFlow<ViewEvent?>(null)
 
     val uiState = combine(
@@ -85,11 +87,18 @@ class HomeViewModel(
         _libraryEntries,
         _airingSeries,
         _trendingEntries,
+        _pendingUpdates,
         _viewEvent,
-    ) { userName, libraryEntries, airingSeries, trending, viewEvent ->
+    ) { userName, libraryEntries, airingSeries, trending, pendingUpdates, viewEvent ->
         UIState(
             username = userName,
-            watchList = libraryEntries,
+            watchList = libraryEntries.map {
+                if (pendingUpdates.contains(it.entryId)) {
+                    it.copy(isUpdating = true)
+                } else {
+                    it
+                }
+            }.toPersistentList(),
             airing = airingSeries,
             trendingAll = trending.trendingAll,
             trendingAnime = trending.trendingAnime,
@@ -119,12 +128,18 @@ class HomeViewModel(
     }
 
     private fun onWatchItemPlusOneClick(watchItem: WatchItem) {
-        // TODO: Update UI in some way?
+        _pendingUpdates.update {
+            it + watchItem.entryId
+        }
         viewModelScope.launch(Dispatchers.IO) {
             libraryRepository.updateEntry(
                 entryId = watchItem.entryId,
                 newProgress = watchItem.progress + 1
             )
+        }.invokeOnCompletion {
+            _pendingUpdates.update {
+                it - watchItem.entryId
+            }
         }
     }
 
@@ -154,7 +169,8 @@ class HomeViewModel(
             posterImage = posterImage.toBestImage(imageQuality),
             progressPercent = progressPercent,
             progress = progress,
-            progressDisplay = "$progress / $displayTotalLength"
+            progressDisplay = "$progress / $displayTotalLength",
+            isUpdating = false
         )
     }
 

--- a/feature/home/src/commonMain/kotlin/com/chesire/nekomp/feature/home/ui/UIState.kt
+++ b/feature/home/src/commonMain/kotlin/com/chesire/nekomp/feature/home/ui/UIState.kt
@@ -21,7 +21,8 @@ data class WatchItem(
     val posterImage: String,
     val progressPercent: Float,
     val progress: Int,
-    val progressDisplay: String
+    val progressDisplay: String,
+    val isUpdating: Boolean
 )
 
 @Stable

--- a/feature/home/src/commonMain/kotlin/com/chesire/nekomp/feature/home/ui/UIState.kt
+++ b/feature/home/src/commonMain/kotlin/com/chesire/nekomp/feature/home/ui/UIState.kt
@@ -20,7 +20,8 @@ data class WatchItem(
     val title: String,
     val posterImage: String,
     val progressPercent: Float,
-    val progress: Int
+    val progress: Int,
+    val progressDisplay: String
 )
 
 @Stable

--- a/feature/home/src/commonMain/kotlin/com/chesire/nekomp/feature/home/ui/components/TrendingListComponent.kt
+++ b/feature/home/src/commonMain/kotlin/com/chesire/nekomp/feature/home/ui/components/TrendingListComponent.kt
@@ -7,10 +7,9 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -41,6 +40,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
+import com.chesire.nekomp.core.ui.theme.Values
 import com.chesire.nekomp.feature.home.ui.TrendItem
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.launch
@@ -173,7 +173,7 @@ private fun TrendItemComponent(
     onTrendItemClick: (TrendItem) -> Unit
 ) {
     Column(
-        modifier = modifier.width(IntrinsicSize.Min),
+        modifier = modifier.size(width = Values.GridItemWidth, height = Values.GridItemHeight),
         verticalArrangement = Arrangement.spacedBy(8.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {

--- a/feature/home/src/commonMain/kotlin/com/chesire/nekomp/feature/home/ui/components/TrendingListComponent.kt
+++ b/feature/home/src/commonMain/kotlin/com/chesire/nekomp/feature/home/ui/components/TrendingListComponent.kt
@@ -179,7 +179,7 @@ private fun TrendItemComponent(
     ) {
         Card(
             onClick = { onTrendItemClick(trendItem) },
-            modifier = Modifier.wrapContentSize(),
+            modifier = Modifier.wrapContentSize()
         ) {
             AsyncImage(
                 model = trendItem.posterImage,

--- a/feature/home/src/commonMain/kotlin/com/chesire/nekomp/feature/home/ui/components/WatchListComponent.kt
+++ b/feature/home/src/commonMain/kotlin/com/chesire/nekomp/feature/home/ui/components/WatchListComponent.kt
@@ -34,6 +34,7 @@ fun WatchListComponent(
                     backgroundImage = it.posterImage,
                     progress = it.progressDisplay,
                     progressPercent = it.progressPercent,
+                    isUpdating = it.isUpdating,
                     modifier = Modifier.animateItem(),
                     onClick = { onWatchItemClick(it) },
                     onPlusClick = { onPlusOneClick(it) }

--- a/feature/home/src/commonMain/kotlin/com/chesire/nekomp/feature/home/ui/components/WatchListComponent.kt
+++ b/feature/home/src/commonMain/kotlin/com/chesire/nekomp/feature/home/ui/components/WatchListComponent.kt
@@ -32,7 +32,8 @@ fun WatchListComponent(
                 SeriesGridItem(
                     title = it.title,
                     backgroundImage = it.posterImage,
-                    progress = it.progressPercent,
+                    progress = it.progressDisplay,
+                    progressPercent = it.progressPercent,
                     modifier = Modifier.animateItem(),
                     onClick = { onWatchItemClick(it) },
                     onPlusClick = { onPlusOneClick(it) }

--- a/feature/home/src/commonMain/kotlin/com/chesire/nekomp/feature/home/ui/components/WatchListComponent.kt
+++ b/feature/home/src/commonMain/kotlin/com/chesire/nekomp/feature/home/ui/components/WatchListComponent.kt
@@ -1,44 +1,18 @@
 package com.chesire.nekomp.feature.home.ui.components
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.PlusOne
-import androidx.compose.material3.Card
-import androidx.compose.material3.Icon
-import androidx.compose.material3.LinearProgressIndicator
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedIconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import coil3.compose.AsyncImage
+import com.chesire.nekomp.core.ui.component.series.SeriesGridItem
 import com.chesire.nekomp.feature.home.ui.WatchItem
 import kotlinx.collections.immutable.ImmutableList
 
-// TODO: Move this somewhere shared to reuse the components?
-// TODO: Make a core:ui module that contains a lot of these shared / almost shared components
 @Composable
 fun WatchListComponent(
     watchItems: ImmutableList<WatchItem>,
@@ -55,89 +29,15 @@ fun WatchListComponent(
                 items = watchItems,
                 key = { it.entryId }
             ) {
-                WatchItemComponent(
-                    watchItem = it,
-                    onWatchItemClick = onWatchItemClick,
+                SeriesGridItem(
+                    title = it.title,
+                    backgroundImage = it.posterImage,
+                    progress = it.progressPercent,
                     modifier = Modifier.animateItem(),
-                    onPlusOneClick = onPlusOneClick
+                    onClick = { onWatchItemClick(it) },
+                    onPlusClick = { onPlusOneClick(it) }
                 )
             }
         }
-    }
-}
-
-@Composable
-private fun WatchItemComponent(
-    watchItem: WatchItem,
-    onWatchItemClick: (WatchItem) -> Unit,
-    modifier: Modifier = Modifier,
-    onPlusOneClick: (WatchItem) -> Unit
-) {
-    var width by remember { mutableStateOf(0.dp) }
-    val density = LocalDensity.current
-
-    Column(
-        modifier = modifier.width(IntrinsicSize.Min),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Card(
-            onClick = { onWatchItemClick(watchItem) },
-            modifier = Modifier.wrapContentSize(),
-        ) {
-            Box(
-                modifier = Modifier
-                    .height(IntrinsicSize.Min)
-                    .width(IntrinsicSize.Min)
-            ) {
-                AsyncImage(
-                    model = watchItem.posterImage,
-                    contentDescription = null,
-                    modifier = Modifier.fillMaxHeight(),
-                    onState = {
-                        width = with(density) {
-                            it.painter?.intrinsicSize?.width?.toInt()?.toDp() ?: 0.dp
-                        }
-                    }
-                )
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(
-                            brush = Brush.verticalGradient(
-                                .5F to Color.Transparent,
-                                .7f to MaterialTheme.colorScheme.background.copy(alpha = 0.5f),
-                                .8f to MaterialTheme.colorScheme.background.copy(alpha = 0.9f),
-                                1F to MaterialTheme.colorScheme.background.copy(alpha = 1f)
-                            )
-                        )
-                )
-                Column(
-                    modifier = Modifier.fillMaxHeight().width(width),
-                    verticalArrangement = Arrangement.Bottom,
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    OutlinedIconButton(onClick = { onPlusOneClick(watchItem) }) {
-                        Icon(
-                            imageVector = Icons.Default.PlusOne,
-                            contentDescription = null // TODO: Add content description
-                        )
-                    }
-                    LinearProgressIndicator(
-                        progress = { watchItem.progressPercent },
-                        modifier = Modifier.height(4.dp),
-                        gapSize = 0.dp,
-                        drawStopIndicator = {}
-                    )
-                }
-            }
-        }
-        Text(
-            text = watchItem.title,
-            style = MaterialTheme.typography.titleSmall,
-            minLines = 2,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis
-        )
     }
 }

--- a/feature/library/src/commonMain/kotlin/com/chesire/nekomp/feature/library/ui/LibraryScreen.kt
+++ b/feature/library/src/commonMain/kotlin/com/chesire/nekomp/feature/library/ui/LibraryScreen.kt
@@ -177,8 +177,8 @@ private fun BottomSheetEventHandler(
 @Preview
 private fun Preview() {
     val state = UIState(
-        entries = persistentListOf<Entry>(
-            Entry(0, "Title1", "", "", 0f, "", 0)
+        entries = persistentListOf(
+            Entry(0, "Title1", "", "", 0f, 0, "0 / -")
         )
     )
     Render(

--- a/feature/library/src/commonMain/kotlin/com/chesire/nekomp/feature/library/ui/LibraryScreen.kt
+++ b/feature/library/src/commonMain/kotlin/com/chesire/nekomp/feature/library/ui/LibraryScreen.kt
@@ -1,7 +1,8 @@
 @file:OptIn(
     ExperimentalComposeUiApi::class,
     ExperimentalMaterial3AdaptiveApi::class,
-    ExperimentalSharedTransitionApi::class, ExperimentalMaterial3Api::class
+    ExperimentalMaterial3Api::class,
+    ExperimentalSharedTransitionApi::class
 )
 
 package com.chesire.nekomp.feature.library.ui
@@ -178,7 +179,17 @@ private fun BottomSheetEventHandler(
 private fun Preview() {
     val state = UIState(
         entries = persistentListOf(
-            Entry(0, "Title1", "", "", 0f, 0, "0 / -")
+            Entry(
+                entryId = 0,
+                title = "Title1",
+                posterImage = "",
+                coverImage = "",
+                progressPercent = 0f,
+                progress = 0,
+                progressDisplay = "0 / -",
+                isUpdating = false,
+                canUpdate = true
+            )
         )
     )
     Render(

--- a/feature/library/src/commonMain/kotlin/com/chesire/nekomp/feature/library/ui/LibraryViewModel.kt
+++ b/feature/library/src/commonMain/kotlin/com/chesire/nekomp/feature/library/ui/LibraryViewModel.kt
@@ -220,13 +220,9 @@ class LibraryViewModel(
             title = titles.toChosenLanguage(titleLanguage),
             posterImage = posterImage.toBestImage(imageQuality),
             coverImage = coverImage.toBestImage(imageQuality),
-            progressPercent = if (totalLength == 0) {
-                0f
-            } else {
-                (progress.toFloat() / totalLength.toFloat())
-            },
-            displayProgress = "$progress / ${totalLength.takeIf { it != 0 } ?: "ongoing"}",
-            progress = progress
+            progressPercent = progressPercent,
+            progress = progress,
+            progressDisplay = "$progress / $displayTotalLength"
         )
     }
 }

--- a/feature/library/src/commonMain/kotlin/com/chesire/nekomp/feature/library/ui/LibraryViewModel.kt
+++ b/feature/library/src/commonMain/kotlin/com/chesire/nekomp/feature/library/ui/LibraryViewModel.kt
@@ -198,7 +198,17 @@ class LibraryViewModel(
     }
 
     private fun onItemPlusOneClick(entry: Entry) = viewModelScope.launch(Dispatchers.IO) {
-        // TODO: Update UI in some way?
+        _uiState.update { state ->
+            val newEntries = state.entries.map {
+                if (it.entryId == entry.entryId) {
+                    it.copy(isUpdating = true)
+                } else {
+                    it
+                }
+            }
+
+            state.copy(entries = newEntries.toPersistentList())
+        }
         libraryRepository.updateEntry(
             entryId = entry.entryId,
             newProgress = entry.progress + 1
@@ -222,7 +232,9 @@ class LibraryViewModel(
             coverImage = coverImage.toBestImage(imageQuality),
             progressPercent = progressPercent,
             progress = progress,
-            progressDisplay = "$progress / $displayTotalLength"
+            progressDisplay = "$progress / $displayTotalLength",
+            isUpdating = false,
+            canUpdate = canIncrementProgress
         )
     }
 }

--- a/feature/library/src/commonMain/kotlin/com/chesire/nekomp/feature/library/ui/UIState.kt
+++ b/feature/library/src/commonMain/kotlin/com/chesire/nekomp/feature/library/ui/UIState.kt
@@ -40,6 +40,6 @@ data class Entry(
     val posterImage: String,
     val coverImage: String,
     val progressPercent: Float,
-    val displayProgress: String,
-    val progress: Int
+    val progress: Int,
+    val progressDisplay: String
 )

--- a/feature/library/src/commonMain/kotlin/com/chesire/nekomp/feature/library/ui/UIState.kt
+++ b/feature/library/src/commonMain/kotlin/com/chesire/nekomp/feature/library/ui/UIState.kt
@@ -41,5 +41,7 @@ data class Entry(
     val coverImage: String,
     val progressPercent: Float,
     val progress: Int,
-    val progressDisplay: String
+    val progressDisplay: String,
+    val isUpdating: Boolean,
+    val canUpdate: Boolean
 )

--- a/feature/library/src/commonMain/kotlin/com/chesire/nekomp/feature/library/ui/pane/CardItemsPane.kt
+++ b/feature/library/src/commonMain/kotlin/com/chesire/nekomp/feature/library/ui/pane/CardItemsPane.kt
@@ -88,7 +88,7 @@ private fun CardItem(
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Text(text = entry.displayProgress)
+                    Text(text = entry.progressDisplay)
                     OutlinedIconButton(onClick = { onPlusOneClick(entry) }) {
                         Icon(
                             imageVector = Icons.Default.PlusOne,

--- a/feature/library/src/commonMain/kotlin/com/chesire/nekomp/feature/library/ui/pane/GridItemsPane.kt
+++ b/feature/library/src/commonMain/kotlin/com/chesire/nekomp/feature/library/ui/pane/GridItemsPane.kt
@@ -34,7 +34,8 @@ internal fun GridItemsPane(
             SeriesGridItem(
                 title = it.title,
                 backgroundImage = it.posterImage,
-                progress = it.progressPercent,
+                progress = it.progressDisplay,
+                progressPercent = it.progressPercent,
                 modifier = Modifier.animateItem(),
                 onClick = { onEntryClick(it) },
                 onPlusClick = { onPlusOneClick(it) }

--- a/feature/library/src/commonMain/kotlin/com/chesire/nekomp/feature/library/ui/pane/GridItemsPane.kt
+++ b/feature/library/src/commonMain/kotlin/com/chesire/nekomp/feature/library/ui/pane/GridItemsPane.kt
@@ -36,7 +36,9 @@ internal fun GridItemsPane(
                 backgroundImage = it.posterImage,
                 progress = it.progressDisplay,
                 progressPercent = it.progressPercent,
+                isUpdating = it.isUpdating,
                 modifier = Modifier.animateItem(),
+                showPlusButton = it.canUpdate,
                 onClick = { onEntryClick(it) },
                 onPlusClick = { onPlusOneClick(it) }
             )

--- a/feature/library/src/commonMain/kotlin/com/chesire/nekomp/feature/library/ui/pane/GridItemsPane.kt
+++ b/feature/library/src/commonMain/kotlin/com/chesire/nekomp/feature/library/ui/pane/GridItemsPane.kt
@@ -1,41 +1,15 @@
 package com.chesire.nekomp.feature.library.ui.pane
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.PlusOne
-import androidx.compose.material3.Card
-import androidx.compose.material3.Icon
-import androidx.compose.material3.LinearProgressIndicator
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedIconButton
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import coil3.compose.AsyncImage
+import com.chesire.nekomp.core.ui.component.series.SeriesGridItem
 import com.chesire.nekomp.feature.library.ui.Entry
 import kotlinx.collections.immutable.ImmutableList
 
@@ -57,89 +31,14 @@ internal fun GridItemsPane(
             items = entries,
             key = { it.entryId }
         ) {
-            GridItem(
-                entry = it,
-                onEntryClick = onEntryClick,
+            SeriesGridItem(
+                title = it.title,
+                backgroundImage = it.posterImage,
+                progress = it.progressPercent,
                 modifier = Modifier.animateItem(),
-                onPlusOneClick = onPlusOneClick
+                onClick = { onEntryClick(it) },
+                onPlusClick = { onPlusOneClick(it) }
             )
         }
-    }
-}
-
-// TODO: Move this into CoreUI to share with home somehow
-@Composable
-private fun GridItem(
-    entry: Entry,
-    onEntryClick: (Entry) -> Unit,
-    modifier: Modifier = Modifier,
-    onPlusOneClick: (Entry) -> Unit
-) {
-    var width by remember { mutableStateOf(0.dp) }
-    val density = LocalDensity.current
-
-    Column(
-        modifier = modifier.width(IntrinsicSize.Min),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Card(
-            onClick = { onEntryClick(entry) },
-            modifier = Modifier.wrapContentSize(),
-        ) {
-            Box(
-                modifier = Modifier
-                    .height(IntrinsicSize.Min)
-                    .width(IntrinsicSize.Min)
-            ) {
-                AsyncImage(
-                    model = entry.posterImage,
-                    contentDescription = null,
-                    modifier = Modifier.fillMaxHeight(),
-                    onState = {
-                        width = with(density) {
-                            it.painter?.intrinsicSize?.width?.toInt()?.toDp() ?: 0.dp
-                        }
-                    }
-                )
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(
-                            brush = Brush.verticalGradient(
-                                .5F to Color.Transparent,
-                                .7f to Color.Black.copy(alpha = 0.5f),
-                                .8f to Color.Black.copy(alpha = 0.9f),
-                                1F to Color.Black.copy(alpha = 1f)
-                            )
-                        )
-                )
-                Column(
-                    modifier = Modifier.fillMaxHeight().width(width),
-                    verticalArrangement = Arrangement.Bottom,
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    OutlinedIconButton(onClick = { onPlusOneClick(entry) }) {
-                        Icon(
-                            imageVector = Icons.Default.PlusOne,
-                            contentDescription = null // TODO: Add content description
-                        )
-                    }
-                    LinearProgressIndicator(
-                        progress = { entry.progressPercent },
-                        modifier = Modifier.height(4.dp),
-                        gapSize = 0.dp,
-                        drawStopIndicator = {}
-                    )
-                }
-            }
-        }
-        Text(
-            text = entry.title,
-            style = MaterialTheme.typography.titleSmall,
-            minLines = 2,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis
-        )
     }
 }

--- a/feature/library/src/commonMain/kotlin/com/chesire/nekomp/feature/library/ui/pane/ListPane.kt
+++ b/feature/library/src/commonMain/kotlin/com/chesire/nekomp/feature/library/ui/pane/ListPane.kt
@@ -145,8 +145,8 @@ private fun Preview() {
     ListPane(
         typeFilters = persistentMapOf(),
         statusFilters = persistentMapOf(),
-        entries = persistentListOf<Entry>(
-            Entry(0, "Title1", "", "", 0f, "", 0)
+        entries = persistentListOf(
+            Entry(0, "Title1", "", "", 0f, 0, "1 / -")
         ),
         currentViewType = ViewType.Card,
         execute = {},

--- a/feature/library/src/commonMain/kotlin/com/chesire/nekomp/feature/library/ui/pane/ListPane.kt
+++ b/feature/library/src/commonMain/kotlin/com/chesire/nekomp/feature/library/ui/pane/ListPane.kt
@@ -146,7 +146,17 @@ private fun Preview() {
         typeFilters = persistentMapOf(),
         statusFilters = persistentMapOf(),
         entries = persistentListOf(
-            Entry(0, "Title1", "", "", 0f, 0, "1 / -")
+            Entry(
+                entryId = 0,
+                title = "Title1",
+                posterImage = "",
+                coverImage = "",
+                progressPercent = 0f,
+                progress = 0,
+                progressDisplay = "1 / -",
+                isUpdating = false,
+                canUpdate = true
+            )
         ),
         currentViewType = ViewType.Card,
         execute = {},

--- a/library/datasource/library/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/library/LibraryEntry.kt
+++ b/library/datasource/library/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/library/LibraryEntry.kt
@@ -41,4 +41,9 @@ data class LibraryEntry(
     } else {
         (progress.toFloat() / totalLength.toFloat())
     }
+
+    /**
+     * Gets if the progress for this series can be incremented.
+     */
+    val canIncrementProgress = if (totalLength == 0) true else progress < totalLength
 }

--- a/library/datasource/library/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/library/LibraryEntry.kt
+++ b/library/datasource/library/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/library/LibraryEntry.kt
@@ -26,4 +26,19 @@ data class LibraryEntry(
     val coverImage: Image,
     val startDate: String,
     val endDate: String
-)
+) {
+
+    /**
+     * Gets a string that can be used to display the total length to the user.
+     */
+    val displayTotalLength = if (totalLength == 0) "-" else totalLength
+
+    /**
+     * Gets the percent of the way through the entry the user is.
+     */
+    val progressPercent = if (totalLength == 0) {
+        0f
+    } else {
+        (progress.toFloat() / totalLength.toFloat())
+    }
+}


### PR DESCRIPTION
- Make the grid item view shared across the app
- Update the UI to show the current progress
- Set static size of grid items
  - This will stop lists changing in size as images are loaded
- Other improvements to the grid item view

![Screenshot 2025-07-05 at 13 34 21](https://github.com/user-attachments/assets/8f81b88c-c6e6-4a2d-bd3f-9077d35cfbe6)
![Screenshot 2025-07-05 at 13 34 26](https://github.com/user-attachments/assets/5cf7de22-2fcc-4af1-a427-97c639006bd2)
