### PR TITLE
[Fix] Application bad state if invalid refresh token in background

### DIFF
--- a/appNekomp/src/commonMain/kotlin/com/chesire/nekomp/App.kt
+++ b/appNekomp/src/commonMain/kotlin/com/chesire/nekomp/App.kt
@@ -73,7 +73,7 @@ fun App() {
 
         LaunchedEffect(Unit) {
             authEventHandler.userLoggedOutEvent.collect {
-                Logger.i("App") { "Auth failed event received, navigating to login" }
+                Logger.i("App") { "User logged out event received, navigating to login" }
                 appNavController.navigate(OriginScreen.Login.name) {
                     popUpTo(0) { inclusive = true }
                 }

--- a/appNekomp/src/commonMain/kotlin/com/chesire/nekomp/App.kt
+++ b/appNekomp/src/commonMain/kotlin/com/chesire/nekomp/App.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffo
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffoldDefaults
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -42,6 +43,7 @@ import com.chesire.nekomp.feature.login.ui.LoginScreen
 import com.chesire.nekomp.feature.profile.ui.ProfileScreen
 import com.chesire.nekomp.feature.settings.ui.SettingsScreen
 import com.chesire.nekomp.library.datasource.auth.AuthRepository
+import com.chesire.nekomp.navigation.AuthEventHandler
 import com.chesire.nekomp.navigation.DashboardDestination
 import com.chesire.nekomp.navigation.OriginScreen
 import org.jetbrains.compose.resources.stringResource
@@ -67,6 +69,17 @@ fun App() {
     NekompTheme(useDarkTheme) {
         val appNavController = rememberNavController()
         val isLoggedIn = !koinInject<AuthRepository>().accessTokenSync().isNullOrBlank()
+        val authEventHandler = koinInject<AuthEventHandler>()
+
+        LaunchedEffect(Unit) {
+            authEventHandler.userLoggedOutEvent.collect {
+                Logger.i("App") { "Auth failed event received, navigating to login" }
+                appNavController.navigate(OriginScreen.Login.name) {
+                    popUpTo(0) { inclusive = true }
+                }
+            }
+        }
+
         Surface(
             modifier = Modifier.fillMaxSize(),
             color = MaterialTheme.colorScheme.background

--- a/appNekomp/src/commonMain/kotlin/com/chesire/nekomp/App.kt
+++ b/appNekomp/src/commonMain/kotlin/com/chesire/nekomp/App.kt
@@ -142,14 +142,7 @@ private fun NavGraphBuilder.addProfile(appNavController: NavController) {
 private fun NavGraphBuilder.addSettings(appNavController: NavController) {
     composable(route = OriginScreen.Settings.name) {
         SettingsScreen(
-            goBack = { appNavController.popBackStack() },
-            onLoggedOut = {
-                appNavController.navigate(OriginScreen.Login.name) {
-                    popUpTo(OriginScreen.Dashboard.name) {
-                        inclusive = true
-                    }
-                }
-            }
+            goBack = { appNavController.popBackStack() }
         )
     }
 }

--- a/appNekomp/src/commonMain/kotlin/com/chesire/nekomp/InitKoin.kt
+++ b/appNekomp/src/commonMain/kotlin/com/chesire/nekomp/InitKoin.kt
@@ -6,6 +6,7 @@ import com.chesire.nekomp.core.coroutines.coroutinesModule
 import com.chesire.nekomp.core.database.databaseModule
 import com.chesire.nekomp.core.preferences.preferencesModule
 import com.chesire.nekomp.di.initializersModule
+import com.chesire.nekomp.di.navigationModule
 import com.chesire.nekomp.di.settingsBinderModule
 import com.chesire.nekomp.feature.airing.featureAiringModule
 import com.chesire.nekomp.feature.discover.featureDiscoverModule
@@ -62,6 +63,7 @@ val koinModules = listOf(
     libraryStatsModule,
     libraryTrendingModule,
     libraryUserModule,
+    navigationModule,
     preferencesModule,
     settingsBinderModule
 )

--- a/appNekomp/src/commonMain/kotlin/com/chesire/nekomp/binder/LogoutBinder.kt
+++ b/appNekomp/src/commonMain/kotlin/com/chesire/nekomp/binder/LogoutBinder.kt
@@ -2,15 +2,16 @@ package com.chesire.nekomp.binder
 
 import co.touchlab.kermit.Logger
 import com.chesire.nekomp.core.database.AppDatabase
+import com.chesire.nekomp.core.network.RefreshErrorExecutor
 import com.chesire.nekomp.feature.settings.core.LogoutExecutor
 import com.chesire.nekomp.library.datasource.auth.AuthRepository
 
 class LogoutBinder(
     private val database: AppDatabase,
     private val authRepository: AuthRepository
-) : LogoutExecutor {
+) : LogoutExecutor, RefreshErrorExecutor {
 
-    override suspend fun execute() {
+    override suspend fun invoke() {
         clearAuth()
         clearDBs()
     }

--- a/appNekomp/src/commonMain/kotlin/com/chesire/nekomp/binder/LogoutBinder.kt
+++ b/appNekomp/src/commonMain/kotlin/com/chesire/nekomp/binder/LogoutBinder.kt
@@ -5,15 +5,18 @@ import com.chesire.nekomp.core.database.AppDatabase
 import com.chesire.nekomp.core.network.RefreshErrorExecutor
 import com.chesire.nekomp.feature.settings.core.LogoutExecutor
 import com.chesire.nekomp.library.datasource.auth.AuthRepository
+import com.chesire.nekomp.navigation.AuthEventHandler
 
 class LogoutBinder(
     private val database: AppDatabase,
-    private val authRepository: AuthRepository
+    private val authRepository: AuthRepository,
+    private val authEventHandler: AuthEventHandler
 ) : LogoutExecutor, RefreshErrorExecutor {
 
     override suspend fun invoke() {
         clearAuth()
         clearDBs()
+        userLoggedOut()
     }
 
     private suspend fun clearAuth() {
@@ -26,5 +29,10 @@ class LogoutBinder(
         database.getUserDao().delete()
         Logger.d("Logout") { "Clearing library entries" }
         database.getLibraryEntryDao().delete()
+    }
+
+    private suspend fun userLoggedOut() {
+        // Emit navigation event to redirect to login
+        authEventHandler.emitUserLoggedOut()
     }
 }

--- a/appNekomp/src/commonMain/kotlin/com/chesire/nekomp/di/NavigationModule.kt
+++ b/appNekomp/src/commonMain/kotlin/com/chesire/nekomp/di/NavigationModule.kt
@@ -1,0 +1,9 @@
+package com.chesire.nekomp.di
+
+import com.chesire.nekomp.navigation.AuthEventHandler
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.module
+
+val navigationModule = module {
+    singleOf(::AuthEventHandler)
+}

--- a/appNekomp/src/commonMain/kotlin/com/chesire/nekomp/di/SettingsBinderModule.kt
+++ b/appNekomp/src/commonMain/kotlin/com/chesire/nekomp/di/SettingsBinderModule.kt
@@ -6,12 +6,11 @@ import com.chesire.nekomp.core.network.RefreshErrorExecutor
 import com.chesire.nekomp.feature.settings.core.LogoutExecutor
 import com.chesire.nekomp.feature.settings.data.ApplicationVersionInfo
 import org.koin.core.module.dsl.factoryOf
-import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.binds
 import org.koin.dsl.module
 
 val settingsBinderModule = module {
     factoryOf(::ApplicationVersionInfoBinder).bind(ApplicationVersionInfo::class)
-    singleOf(::LogoutBinder).binds(arrayOf(LogoutExecutor::class, RefreshErrorExecutor::class))
+    factoryOf(::LogoutBinder).binds(arrayOf(LogoutExecutor::class, RefreshErrorExecutor::class))
 }

--- a/appNekomp/src/commonMain/kotlin/com/chesire/nekomp/di/SettingsBinderModule.kt
+++ b/appNekomp/src/commonMain/kotlin/com/chesire/nekomp/di/SettingsBinderModule.kt
@@ -2,13 +2,16 @@ package com.chesire.nekomp.di
 
 import com.chesire.nekomp.binder.ApplicationVersionInfoBinder
 import com.chesire.nekomp.binder.LogoutBinder
+import com.chesire.nekomp.core.network.RefreshErrorExecutor
 import com.chesire.nekomp.feature.settings.core.LogoutExecutor
 import com.chesire.nekomp.feature.settings.data.ApplicationVersionInfo
 import org.koin.core.module.dsl.factoryOf
+import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
+import org.koin.dsl.binds
 import org.koin.dsl.module
 
 val settingsBinderModule = module {
     factoryOf(::ApplicationVersionInfoBinder).bind(ApplicationVersionInfo::class)
-    factoryOf(::LogoutBinder).bind(LogoutExecutor::class)
+    singleOf(::LogoutBinder).binds(arrayOf(LogoutExecutor::class, RefreshErrorExecutor::class))
 }

--- a/appNekomp/src/commonMain/kotlin/com/chesire/nekomp/navigation/AuthEventHandler.kt
+++ b/appNekomp/src/commonMain/kotlin/com/chesire/nekomp/navigation/AuthEventHandler.kt
@@ -1,0 +1,16 @@
+package com.chesire.nekomp.navigation
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+class AuthEventHandler {
+
+    private val _userLoggedOutEvent = MutableSharedFlow<Unit>()
+
+    val userLoggedOutEvent: SharedFlow<Unit> = _userLoggedOutEvent.asSharedFlow()
+
+    suspend fun emitUserLoggedOut() {
+        _userLoggedOutEvent.emit(Unit)
+    }
+}

--- a/core/coroutines/src/commonMain/kotlin/com/chesire/nekomp/core/coroutines/FlowExt.kt
+++ b/core/coroutines/src/commonMain/kotlin/com/chesire/nekomp/core/coroutines/FlowExt.kt
@@ -20,6 +20,30 @@ fun <T> Flow<T>.emitLatestPeriodically(interval: Duration): Flow<T> = transformL
 }
 
 /**
+ * Performs a [combine] with 5 elements.
+ */
+@Suppress("MagicNumber")
+inline fun <T1, T2, T3, T4, T5, R> combine(
+    flow: Flow<T1>,
+    flow2: Flow<T2>,
+    flow3: Flow<T3>,
+    flow4: Flow<T4>,
+    flow5: Flow<T5>,
+    crossinline transform: suspend (T1, T2, T3, T4, T5) -> R
+): Flow<R> {
+    return combine(flow, flow2, flow3, flow4, flow5) { args: Array<*> ->
+        @Suppress("UNCHECKED_CAST")
+        transform(
+            args[0] as T1,
+            args[1] as T2,
+            args[2] as T3,
+            args[3] as T4,
+            args[4] as T5
+        )
+    }
+}
+
+/**
  * Performs a [combine] with 6 elements.
  */
 @Suppress("MagicNumber")

--- a/core/network/src/commonMain/kotlin/com/chesire/nekomp/core/network/RefreshErrorExecutor.kt
+++ b/core/network/src/commonMain/kotlin/com/chesire/nekomp/core/network/RefreshErrorExecutor.kt
@@ -1,0 +1,6 @@
+package com.chesire.nekomp.core.network
+
+fun interface RefreshErrorExecutor {
+
+    suspend operator fun invoke()
+}

--- a/core/network/src/commonMain/kotlin/com/chesire/nekomp/core/network/plugin/InstallAuth.kt
+++ b/core/network/src/commonMain/kotlin/com/chesire/nekomp/core/network/plugin/InstallAuth.kt
@@ -9,7 +9,7 @@ import io.ktor.http.HttpStatusCode
 
 fun HttpClientConfig<*>.installAuth(
     getTokens: suspend () -> BearerTokens,
-    refreshTokens: suspend () -> Unit
+    refreshTokens: suspend () -> Boolean
 ) {
     install(Auth) {
         reAuthorizeOnResponse { response ->
@@ -23,8 +23,13 @@ fun HttpClientConfig<*>.installAuth(
 
             refreshTokens {
                 Logger.i("HttpClient") { "Refreshing auth tokens" }
-                refreshTokens()
-                getTokens()
+                val tokensRefreshed = refreshTokens()
+                if (tokensRefreshed) {
+                    getTokens()
+                } else {
+                    // Execute logout in some way
+                    error()
+                }
             }
         }
     }

--- a/core/network/src/commonMain/kotlin/com/chesire/nekomp/core/network/plugin/InstallAuth.kt
+++ b/core/network/src/commonMain/kotlin/com/chesire/nekomp/core/network/plugin/InstallAuth.kt
@@ -7,9 +7,15 @@ import io.ktor.client.plugins.auth.providers.BearerTokens
 import io.ktor.client.plugins.auth.providers.bearer
 import io.ktor.http.HttpStatusCode
 
+/**
+ * [refreshTokens] is a lambda that if true means that the tokens could not be refreshed so a logout
+ * will occur.
+ * [onRefreshError] is called when tokens cannot be refreshed and logout should occur.
+ */
 fun HttpClientConfig<*>.installAuth(
     getTokens: suspend () -> BearerTokens,
-    refreshTokens: suspend () -> Boolean
+    refreshTokens: suspend () -> Boolean,
+    onRefreshError: suspend () -> Unit
 ) {
     install(Auth) {
         reAuthorizeOnResponse { response ->
@@ -23,11 +29,13 @@ fun HttpClientConfig<*>.installAuth(
 
             refreshTokens {
                 Logger.i("HttpClient") { "Refreshing auth tokens" }
-                val tokensRefreshed = refreshTokens()
-                if (tokensRefreshed) {
-                    getTokens()
+                val invalidTokens = refreshTokens()
+                if (invalidTokens) {
+                    Logger.e("HttpClient") { "Token refresh failed, executing logout" }
+                    onRefreshError()
+                    error("Could not refresh tokens, logout executed")
                 } else {
-                    error("Could not refresh, throwing an error")
+                    getTokens()
                 }
             }
         }

--- a/core/network/src/commonMain/kotlin/com/chesire/nekomp/core/network/plugin/InstallAuth.kt
+++ b/core/network/src/commonMain/kotlin/com/chesire/nekomp/core/network/plugin/InstallAuth.kt
@@ -27,8 +27,7 @@ fun HttpClientConfig<*>.installAuth(
                 if (tokensRefreshed) {
                     getTokens()
                 } else {
-                    // Execute logout in some way
-                    error()
+                    error("Could not refresh, throwing an error")
                 }
             }
         }

--- a/core/ui/src/commonMain/kotlin/com/chesire/nekomp/core/ui/component/SettingSheet.kt
+++ b/core/ui/src/commonMain/kotlin/com/chesire/nekomp/core/ui/component/SettingSheet.kt
@@ -16,7 +16,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableMap
 
 @Composable

--- a/feature/login/src/commonMain/kotlin/com/chesire/nekomp/feature/login/ui/LoginViewModel.kt
+++ b/feature/login/src/commonMain/kotlin/com/chesire/nekomp/feature/login/ui/LoginViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.chesire.nekomp.core.resources.NekoRes
 import com.chesire.nekomp.feature.login.core.LoadDataUseCase
 import com.chesire.nekomp.feature.login.core.PerformLoginUseCase
+import com.chesire.nekomp.feature.login.ui.ViewEvent.LoginFailure
 import com.chesire.nekomp.library.datasource.auth.AuthFailure
 import com.github.michaelbull.result.onSuccess
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -56,12 +57,16 @@ class LoginViewModel(
                     ViewEvent.LoginSuccessful
                 } else {
                     when (loginResult.error) {
-                        AuthFailure.BadRequest -> ViewEvent.LoginFailure(
+                        AuthFailure.BadRequest -> LoginFailure(
                             getString(NekoRes.string.login_error_generic)
                         )
 
-                        AuthFailure.InvalidCredentials -> ViewEvent.LoginFailure(
+                        AuthFailure.InvalidCredentials -> LoginFailure(
                             getString(NekoRes.string.login_error_invalid_credentials)
+                        )
+
+                        AuthFailure.BadToken -> LoginFailure(
+                            getString(NekoRes.string.login_error_generic)
                         )
                     }
                 }

--- a/feature/settings/src/commonMain/kotlin/com/chesire/nekomp/feature/settings/core/LogoutExecutor.kt
+++ b/feature/settings/src/commonMain/kotlin/com/chesire/nekomp/feature/settings/core/LogoutExecutor.kt
@@ -2,5 +2,5 @@ package com.chesire.nekomp.feature.settings.core
 
 fun interface LogoutExecutor {
 
-    suspend fun execute()
+    suspend operator fun invoke()
 }

--- a/feature/settings/src/commonMain/kotlin/com/chesire/nekomp/feature/settings/ext/ModelsExt.kt
+++ b/feature/settings/src/commonMain/kotlin/com/chesire/nekomp/feature/settings/ext/ModelsExt.kt
@@ -1,8 +1,8 @@
 package com.chesire.nekomp.feature.settings.ext
 
-import com.chesire.nekomp.core.preferences.ImageQuality
-import com.chesire.nekomp.core.preferences.Theme
-import com.chesire.nekomp.core.preferences.TitleLanguage
+import com.chesire.nekomp.core.preferences.models.ImageQuality
+import com.chesire.nekomp.core.preferences.models.Theme
+import com.chesire.nekomp.core.preferences.models.TitleLanguage
 import com.chesire.nekomp.core.resources.NekoRes
 import nekomp.core.resources.generated.resources.settings_image_quality_high
 import nekomp.core.resources.generated.resources.settings_image_quality_highest

--- a/feature/settings/src/commonMain/kotlin/com/chesire/nekomp/feature/settings/ui/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/chesire/nekomp/feature/settings/ui/SettingsScreen.kt
@@ -83,15 +83,13 @@ import org.koin.compose.viewmodel.koinViewModel
 @Composable
 fun SettingsScreen(
     viewModel: SettingsViewModel = koinViewModel(),
-    goBack: () -> Unit,
-    onLoggedOut: () -> Unit
+    goBack: () -> Unit
 ) {
     val state by viewModel.uiState.collectAsState()
 
     Render(
         state = state,
         goBack = goBack,
-        onLoggedOut = onLoggedOut,
         execute = { viewModel.execute(it) }
     )
 }
@@ -101,20 +99,9 @@ fun SettingsScreen(
 private fun Render(
     state: UIState,
     goBack: () -> Unit,
-    onLoggedOut: () -> Unit,
     execute: (ViewAction) -> Unit
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
-    LaunchedEffect(state.viewEvent) {
-        when (state.viewEvent) {
-            ViewEvent.LoggedOut -> onLoggedOut()
-            null -> Unit
-        }
-
-        if (state.viewEvent != null) {
-            execute(ViewAction.ObservedViewEvent)
-        }
-    }
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -433,7 +420,6 @@ private fun Preview() {
     Render(
         state = state,
         goBack = {},
-        onLoggedOut = {},
         execute = {}
     )
 }

--- a/feature/settings/src/commonMain/kotlin/com/chesire/nekomp/feature/settings/ui/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/chesire/nekomp/feature/settings/ui/SettingsViewModel.kt
@@ -130,7 +130,7 @@ class SettingsViewModel(
     }
 
     private fun onLogoutClick() = viewModelScope.launch {
-        logout.execute()
+        logout.invoke()
         _viewEvent.update { ViewEvent.LoggedOut }
     }
 

--- a/feature/settings/src/commonMain/kotlin/com/chesire/nekomp/feature/settings/ui/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/chesire/nekomp/feature/settings/ui/SettingsViewModel.kt
@@ -27,23 +27,20 @@ class SettingsViewModel(
     private val _appVersion =
         "${applicationVersionInfo.versionName} (${applicationVersionInfo.versionCode})"
     private val _bottomSheet = MutableStateFlow<SettingsBottomSheet?>(null)
-    private val _viewEvent = MutableStateFlow<ViewEvent?>(null)
 
     val uiState = combine(
         applicationSettings.theme,
         applicationSettings.titleLanguage,
         applicationSettings.imageQuality,
         applicationSettings.rateOnFinish,
-        _viewEvent,
         _bottomSheet
-    ) { theme, titleLanguage, imageQuality, rateOnFinish, viewEvent, bottomSheet ->
+    ) { theme, titleLanguage, imageQuality, rateOnFinish, bottomSheet ->
         UIState(
             currentTheme = theme.name,
             titleLanguage = titleLanguage.name,
             imageQuality = imageQuality.name,
             rateChecked = rateOnFinish,
             version = _appVersion,
-            viewEvent = viewEvent,
             bottomSheet = bottomSheet
         )
     }.stateIn(
@@ -66,7 +63,6 @@ class SettingsViewModel(
             ViewAction.RateChanged -> onRateChanged()
 
             ViewAction.LogoutClick -> onLogoutClick()
-            ViewAction.ObservedViewEvent -> onObservedViewEvent()
         }
     }
 
@@ -130,9 +126,7 @@ class SettingsViewModel(
     }
 
     private fun onLogoutClick() = viewModelScope.launch {
+        // the app module will handle navigating the user after this call
         logout.invoke()
-        _viewEvent.update { ViewEvent.LoggedOut }
     }
-
-    private fun onObservedViewEvent() = _viewEvent.update { null }
 }

--- a/feature/settings/src/commonMain/kotlin/com/chesire/nekomp/feature/settings/ui/UIState.kt
+++ b/feature/settings/src/commonMain/kotlin/com/chesire/nekomp/feature/settings/ui/UIState.kt
@@ -11,7 +11,6 @@ data class UIState(
     val imageQuality: String = "",
     val rateChecked: Boolean = false,
     val version: String = "",
-    val viewEvent: ViewEvent? = null,
     val bottomSheet: SettingsBottomSheet? = null
 )
 

--- a/feature/settings/src/commonMain/kotlin/com/chesire/nekomp/feature/settings/ui/ViewAction.kt
+++ b/feature/settings/src/commonMain/kotlin/com/chesire/nekomp/feature/settings/ui/ViewAction.kt
@@ -18,6 +18,4 @@ sealed interface ViewAction {
     data object RateChanged : ViewAction
 
     data object LogoutClick : ViewAction
-
-    data object ObservedViewEvent : ViewAction
 }

--- a/feature/settings/src/commonMain/kotlin/com/chesire/nekomp/feature/settings/ui/ViewEvent.kt
+++ b/feature/settings/src/commonMain/kotlin/com/chesire/nekomp/feature/settings/ui/ViewEvent.kt
@@ -1,5 +1,0 @@
-package com.chesire.nekomp.feature.settings.ui
-
-sealed interface ViewEvent {
-    data object LoggedOut : ViewEvent
-}

--- a/feature/settings/src/commonTest/kotlin/com/chesire/nekomp/feature/settings/ui/SettingsViewModelTest.kt
+++ b/feature/settings/src/commonTest/kotlin/com/chesire/nekomp/feature/settings/ui/SettingsViewModelTest.kt
@@ -63,7 +63,6 @@ class SettingsViewModelTest : FunSpec({
                 imageQuality.shouldBe("High")
                 rateChecked.shouldBe(true)
                 version.shouldBe("0.0.0 (0)")
-                viewEvent.shouldBeNull()
                 bottomSheet.shouldBeNull()
             }
         }
@@ -171,17 +170,5 @@ class SettingsViewModelTest : FunSpec({
         viewModel.execute(ViewAction.LogoutClick)
 
         verifySuspend { logout.invoke() }
-    }
-
-    test("When onObservedViewEvent, Then viewEvent is reset") {
-        viewModel.uiState.test {
-            skipItems(1)
-            viewModel.execute(ViewAction.LogoutClick)
-            awaitItem().viewEvent.shouldBe(ViewEvent.LoggedOut)
-
-            viewModel.execute(ViewAction.ObservedViewEvent)
-
-            awaitItem().viewEvent.shouldBeNull()
-        }
     }
 })

--- a/feature/settings/src/commonTest/kotlin/com/chesire/nekomp/feature/settings/ui/SettingsViewModelTest.kt
+++ b/feature/settings/src/commonTest/kotlin/com/chesire/nekomp/feature/settings/ui/SettingsViewModelTest.kt
@@ -170,7 +170,7 @@ class SettingsViewModelTest : FunSpec({
     test("When onLogoutClick, Then logout is executed") {
         viewModel.execute(ViewAction.LogoutClick)
 
-        verifySuspend { logout.execute() }
+        verifySuspend { logout.invoke() }
     }
 
     test("When onObservedViewEvent, Then viewEvent is reset") {

--- a/library/datasource/auth/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/auth/AuthRepository.kt
+++ b/library/datasource/auth/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/auth/AuthRepository.kt
@@ -44,6 +44,7 @@ class AuthRepository(
                     val type = when (it) {
                         is NetworkError.ApiError -> when (it.code) {
                             HttpStatusCode.Unauthorized.value -> AuthFailure.InvalidCredentials
+                            HttpStatusCode.BadRequest.value -> AuthFailure.BadToken
                             else -> AuthFailure.BadRequest
                         }
 
@@ -60,7 +61,7 @@ class AuthRepository(
             .onSuccess { updateTokens(it.accessToken, it.refreshToken) }
             .mapBoth(
                 success = {
-                    Logger.e("AuthRepository") { "Token refresh successful" }
+                    Logger.i("AuthRepository") { "Token refresh successful" }
                     Ok(it.accessToken)
                 },
                 failure = {
@@ -70,6 +71,7 @@ class AuthRepository(
                     val type = when (it) {
                         is NetworkError.ApiError -> when (it.code) {
                             HttpStatusCode.Unauthorized.value -> AuthFailure.InvalidCredentials
+                            HttpStatusCode.BadRequest.value -> AuthFailure.BadToken
                             else -> AuthFailure.BadRequest
                         }
 
@@ -89,5 +91,6 @@ class AuthRepository(
 
 sealed interface AuthFailure {
     data object InvalidCredentials : AuthFailure
+    data object BadToken : AuthFailure
     data object BadRequest : AuthFailure
 }

--- a/library/datasource/auth/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/auth/AuthRepository.kt
+++ b/library/datasource/auth/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/auth/AuthRepository.kt
@@ -2,7 +2,6 @@ package com.chesire.nekomp.library.datasource.auth
 
 import co.touchlab.kermit.Logger
 import com.chesire.nekomp.core.network.NetworkError
-import com.chesire.nekomp.core.network.RefreshErrorExecutor
 import com.chesire.nekomp.library.datasource.auth.local.AuthStorage
 import com.chesire.nekomp.library.datasource.auth.remote.AuthApi
 import com.chesire.nekomp.library.datasource.auth.remote.model.GRANT_TYPE_PASSWORD
@@ -20,8 +19,7 @@ import kotlinx.coroutines.runBlocking
 // TODO: Add a remote data source to handle all this parsing etc
 class AuthRepository(
     private val authApi: AuthApi,
-    private val authStorage: AuthStorage,
-    private val refreshErrorExecutor: RefreshErrorExecutor
+    private val authStorage: AuthStorage
 ) {
 
     // This will do for now
@@ -71,12 +69,7 @@ class AuthRepository(
                     }
                     val type = when (it) {
                         is NetworkError.ApiError -> when (it.code) {
-                            HttpStatusCode.Unauthorized.value -> {
-                                // Unauthorized means the refresh token wasn't valid, execute logout
-                                //refreshErrorExecutor()
-                                AuthFailure.InvalidCredentials
-                            }
-
+                            HttpStatusCode.Unauthorized.value -> AuthFailure.InvalidCredentials
                             else -> AuthFailure.BadRequest
                         }
 

--- a/library/datasource/favorite/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/favorite/LibraryFavoriteModule.kt
+++ b/library/datasource/favorite/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/favorite/LibraryFavoriteModule.kt
@@ -33,7 +33,8 @@ val libraryFavoriteModule = module {
                             )
                         },
                         refreshTokens = {
-                            get<AuthRepository>().refresh().error is AuthFailure.InvalidCredentials
+                            val result = get<AuthRepository>().refresh()
+                            result.error is AuthFailure.BadToken
                         },
                         onRefreshError = {
                             get<RefreshErrorExecutor>().invoke()

--- a/library/datasource/favorite/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/favorite/LibraryFavoriteModule.kt
+++ b/library/datasource/favorite/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/favorite/LibraryFavoriteModule.kt
@@ -1,9 +1,11 @@
 package com.chesire.nekomp.library.datasource.favorite
 
+import com.chesire.nekomp.core.network.RefreshErrorExecutor
 import com.chesire.nekomp.core.network.ResultConverterFactory
 import com.chesire.nekomp.core.network.plugin.installAuth
 import com.chesire.nekomp.core.network.plugin.installContentNegotiation
 import com.chesire.nekomp.core.network.plugin.installLogging
+import com.chesire.nekomp.library.datasource.auth.AuthFailure
 import com.chesire.nekomp.library.datasource.auth.AuthRepository
 import com.chesire.nekomp.library.datasource.favorite.local.FavoriteStorage
 import com.chesire.nekomp.library.datasource.favorite.remote.FavoriteApi
@@ -31,7 +33,10 @@ val libraryFavoriteModule = module {
                             )
                         },
                         refreshTokens = {
-                            get<AuthRepository>().refresh().isOk
+                            get<AuthRepository>().refresh().error is AuthFailure.InvalidCredentials
+                        },
+                        onRefreshError = {
+                            get<RefreshErrorExecutor>().invoke()
                         }
                     )
                 }

--- a/library/datasource/favorite/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/favorite/LibraryFavoriteModule.kt
+++ b/library/datasource/favorite/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/favorite/LibraryFavoriteModule.kt
@@ -31,7 +31,7 @@ val libraryFavoriteModule = module {
                             )
                         },
                         refreshTokens = {
-                            get<AuthRepository>().refresh()
+                            get<AuthRepository>().refresh().isOk
                         }
                     )
                 }

--- a/library/datasource/library/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/library/LibraryLibraryModule.kt
+++ b/library/datasource/library/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/library/LibraryLibraryModule.kt
@@ -31,7 +31,7 @@ val libraryLibraryModule = module {
                             )
                         },
                         refreshTokens = {
-                            get<AuthRepository>().refresh()
+                            get<AuthRepository>().refresh().isOk
                         }
                     )
                 }

--- a/library/datasource/library/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/library/LibraryLibraryModule.kt
+++ b/library/datasource/library/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/library/LibraryLibraryModule.kt
@@ -33,7 +33,8 @@ val libraryLibraryModule = module {
                             )
                         },
                         refreshTokens = {
-                            get<AuthRepository>().refresh().error is AuthFailure.InvalidCredentials
+                            val result = get<AuthRepository>().refresh()
+                            result.error is AuthFailure.BadToken
                         },
                         onRefreshError = {
                             get<RefreshErrorExecutor>().invoke()

--- a/library/datasource/library/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/library/LibraryLibraryModule.kt
+++ b/library/datasource/library/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/library/LibraryLibraryModule.kt
@@ -1,9 +1,11 @@
 package com.chesire.nekomp.library.datasource.library
 
+import com.chesire.nekomp.core.network.RefreshErrorExecutor
 import com.chesire.nekomp.core.network.ResultConverterFactory
 import com.chesire.nekomp.core.network.plugin.installAuth
 import com.chesire.nekomp.core.network.plugin.installContentNegotiation
 import com.chesire.nekomp.core.network.plugin.installLogging
+import com.chesire.nekomp.library.datasource.auth.AuthFailure
 import com.chesire.nekomp.library.datasource.auth.AuthRepository
 import com.chesire.nekomp.library.datasource.library.local.LibraryStorage
 import com.chesire.nekomp.library.datasource.library.remote.LibraryApi
@@ -31,7 +33,10 @@ val libraryLibraryModule = module {
                             )
                         },
                         refreshTokens = {
-                            get<AuthRepository>().refresh().isOk
+                            get<AuthRepository>().refresh().error is AuthFailure.InvalidCredentials
+                        },
+                        onRefreshError = {
+                            get<RefreshErrorExecutor>().invoke()
                         }
                     )
                 }

--- a/library/datasource/search/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/search/LibrarySearchModule.kt
+++ b/library/datasource/search/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/search/LibrarySearchModule.kt
@@ -1,9 +1,11 @@
 package com.chesire.nekomp.library.datasource.search
 
+import com.chesire.nekomp.core.network.RefreshErrorExecutor
 import com.chesire.nekomp.core.network.ResultConverterFactory
 import com.chesire.nekomp.core.network.plugin.installAuth
 import com.chesire.nekomp.core.network.plugin.installContentNegotiation
 import com.chesire.nekomp.core.network.plugin.installLogging
+import com.chesire.nekomp.library.datasource.auth.AuthFailure
 import com.chesire.nekomp.library.datasource.auth.AuthRepository
 import com.chesire.nekomp.library.datasource.search.remote.SearchApi
 import com.chesire.nekomp.library.datasource.search.remote.createSearchApi
@@ -30,7 +32,10 @@ val librarySearchModule = module {
                             )
                         },
                         refreshTokens = {
-                            get<AuthRepository>().refresh().isOk
+                            get<AuthRepository>().refresh().error is AuthFailure.InvalidCredentials
+                        },
+                        onRefreshError = {
+                            get<RefreshErrorExecutor>().invoke()
                         }
                     )
                 }

--- a/library/datasource/search/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/search/LibrarySearchModule.kt
+++ b/library/datasource/search/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/search/LibrarySearchModule.kt
@@ -30,7 +30,7 @@ val librarySearchModule = module {
                             )
                         },
                         refreshTokens = {
-                            get<AuthRepository>().refresh()
+                            get<AuthRepository>().refresh().isOk
                         }
                     )
                 }

--- a/library/datasource/search/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/search/LibrarySearchModule.kt
+++ b/library/datasource/search/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/search/LibrarySearchModule.kt
@@ -32,7 +32,8 @@ val librarySearchModule = module {
                             )
                         },
                         refreshTokens = {
-                            get<AuthRepository>().refresh().error is AuthFailure.InvalidCredentials
+                            val result = get<AuthRepository>().refresh()
+                            result.error is AuthFailure.BadToken
                         },
                         onRefreshError = {
                             get<RefreshErrorExecutor>().invoke()

--- a/library/datasource/stats/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/stats/LibraryStatsModule.kt
+++ b/library/datasource/stats/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/stats/LibraryStatsModule.kt
@@ -33,7 +33,8 @@ val libraryStatsModule = module {
                             )
                         },
                         refreshTokens = {
-                            get<AuthRepository>().refresh().error is AuthFailure.InvalidCredentials
+                            val result = get<AuthRepository>().refresh()
+                            result.error is AuthFailure.BadToken
                         },
                         onRefreshError = {
                             get<RefreshErrorExecutor>().invoke()

--- a/library/datasource/stats/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/stats/LibraryStatsModule.kt
+++ b/library/datasource/stats/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/stats/LibraryStatsModule.kt
@@ -1,9 +1,11 @@
 package com.chesire.nekomp.library.datasource.stats
 
+import com.chesire.nekomp.core.network.RefreshErrorExecutor
 import com.chesire.nekomp.core.network.ResultConverterFactory
 import com.chesire.nekomp.core.network.plugin.installAuth
 import com.chesire.nekomp.core.network.plugin.installContentNegotiation
 import com.chesire.nekomp.core.network.plugin.installLogging
+import com.chesire.nekomp.library.datasource.auth.AuthFailure
 import com.chesire.nekomp.library.datasource.auth.AuthRepository
 import com.chesire.nekomp.library.datasource.stats.local.StatsStorage
 import com.chesire.nekomp.library.datasource.stats.remote.StatsApi
@@ -31,7 +33,10 @@ val libraryStatsModule = module {
                             )
                         },
                         refreshTokens = {
-                            get<AuthRepository>().refresh().isOk
+                            get<AuthRepository>().refresh().error is AuthFailure.InvalidCredentials
+                        },
+                        onRefreshError = {
+                            get<RefreshErrorExecutor>().invoke()
                         }
                     )
                 }

--- a/library/datasource/stats/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/stats/LibraryStatsModule.kt
+++ b/library/datasource/stats/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/stats/LibraryStatsModule.kt
@@ -31,7 +31,7 @@ val libraryStatsModule = module {
                             )
                         },
                         refreshTokens = {
-                            get<AuthRepository>().refresh()
+                            get<AuthRepository>().refresh().isOk
                         }
                     )
                 }

--- a/library/datasource/user/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/user/LibraryUserModule.kt
+++ b/library/datasource/user/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/user/LibraryUserModule.kt
@@ -35,7 +35,8 @@ val libraryUserModule = module {
                             )
                         },
                         refreshTokens = {
-                            get<AuthRepository>().refresh().error is AuthFailure.InvalidCredentials
+                            val result = get<AuthRepository>().refresh()
+                            result.error is AuthFailure.BadToken
                         },
                         onRefreshError = {
                             get<RefreshErrorExecutor>().invoke()

--- a/library/datasource/user/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/user/LibraryUserModule.kt
+++ b/library/datasource/user/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/user/LibraryUserModule.kt
@@ -1,9 +1,11 @@
 package com.chesire.nekomp.library.datasource.user
 
+import com.chesire.nekomp.core.network.RefreshErrorExecutor
 import com.chesire.nekomp.core.network.ResultConverterFactory
 import com.chesire.nekomp.core.network.plugin.installAuth
 import com.chesire.nekomp.core.network.plugin.installContentNegotiation
 import com.chesire.nekomp.core.network.plugin.installLogging
+import com.chesire.nekomp.library.datasource.auth.AuthFailure
 import com.chesire.nekomp.library.datasource.auth.AuthRepository
 import com.chesire.nekomp.library.datasource.user.local.UserLocalDataSource
 import com.chesire.nekomp.library.datasource.user.local.UserStorage
@@ -33,7 +35,10 @@ val libraryUserModule = module {
                             )
                         },
                         refreshTokens = {
-                            get<AuthRepository>().refresh().isOk
+                            get<AuthRepository>().refresh().error is AuthFailure.InvalidCredentials
+                        },
+                        onRefreshError = {
+                            get<RefreshErrorExecutor>().invoke()
                         }
                     )
                 }

--- a/library/datasource/user/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/user/LibraryUserModule.kt
+++ b/library/datasource/user/src/commonMain/kotlin/com/chesire/nekomp/library/datasource/user/LibraryUserModule.kt
@@ -33,7 +33,7 @@ val libraryUserModule = module {
                             )
                         },
                         refreshTokens = {
-                            get<AuthRepository>().refresh()
+                            get<AuthRepository>().refresh().isOk
                         }
                     )
                 }


### PR DESCRIPTION
App doesn't handle expired tokens gracefully when user is already logged in.
If the user cannot refresh their auth tokens (especially via a background worker) the user remains logged in, but they cannot do anything in the application.
This change executes a logout if the auth tokens cannot be refreshed, and kicks them back to the login screen if the app is currently open.